### PR TITLE
Reflect search field on check-boxes in Predefined Filters

### DIFF
--- a/src/ui/include/crawlerwidget.h
+++ b/src/ui/include/crawlerwidget.h
@@ -317,6 +317,7 @@ class CrawlerWidget : public QSplitter,
     void changeDataStatus( DataStatus status );
     void updateEncoding();
     void changeTopViewSize( int32_t delta );
+    void updatePredefinedFiltersWidget();
 
     // Reload predefined filters after changing settings
     void reloadPredefinedFilters() const;

--- a/src/ui/include/predefinedfilterscombobox.h
+++ b/src/ui/include/predefinedfilterscombobox.h
@@ -58,6 +58,9 @@ class PredefinedFiltersComboBox final : public QComboBox {
     PredefinedFiltersComboBox& operator=( PredefinedFiltersComboBox&& other ) = delete;
 
     void populatePredefinedFilters();
+    void updateSearchPattern( const QString newSearchPattern, bool useLogicalCombining );
+
+    virtual void showPopup();
 
   Q_SIGNALS:
     void filterChanged( const QList<PredefinedFilter>& selectedFilters);
@@ -71,6 +74,12 @@ class PredefinedFiltersComboBox final : public QComboBox {
     PredefinedFiltersCollection filtersCollection_;
 
     QStandardItemModel* model_;
+    struct {
+        QString lastOne;
+        QString newOne;
+        bool useLogicalCombining;
+    } searchPattern_;
+    bool ignoreCollecting_;
 };
 
 #endif

--- a/src/ui/src/crawlerwidget.cpp
+++ b/src/ui/src/crawlerwidget.cpp
@@ -384,6 +384,11 @@ void CrawlerWidget::startNewSearch()
     replaceCurrentSearch( searchLineEdit_->currentText() );
 }
 
+void CrawlerWidget::updatePredefinedFiltersWidget()
+{
+    predefinedFilters_->updateSearchPattern( searchLineEdit_->currentText(), booleanButton_->isChecked() );
+}
+
 void CrawlerWidget::stopSearch()
 {
     logFilteredData_->interruptSearch();
@@ -778,6 +783,7 @@ void CrawlerWidget::useRegexpChangeHandler( bool )
 void CrawlerWidget::searchTextChangeHandler( QString )
 {
     resetStateOnSearchPatternChanges();
+    updatePredefinedFiltersWidget();
 }
 
 void CrawlerWidget::changeFilteredViewVisibility( int index )
@@ -867,6 +873,7 @@ void CrawlerWidget::replaceSearch( const QString& searchString )
 void CrawlerWidget::setSearchPattern( const QString& searchPattern )
 {
     searchLineEdit_->setEditText( searchPattern );
+    updatePredefinedFiltersWidget();
     // Set the focus to lineEdit so that the user can press 'Return' immediately
     searchLineEdit_->lineEdit()->setFocus();
 
@@ -1111,6 +1118,11 @@ void CrawlerWidget::setup()
              &QToolButton::click );
     connect( searchLineEdit_->lineEdit(), &QLineEdit::textEdited, this,
              &CrawlerWidget::searchTextChangeHandler );
+
+    connect( searchLineEdit_, QOverload<int>::of( &QComboBox::currentIndexChanged ), this,
+             [ this ]( auto ) {
+                 updatePredefinedFiltersWidget();
+             } );
 
     connect( predefinedFilters_, &PredefinedFiltersComboBox::filterChanged, this,
              &CrawlerWidget::setSearchPatternFromPredefinedFilters );


### PR DESCRIPTION
User input from search line field is reflected in Predefined Filters menu, i. e. any predefined filter is marked as checked if it is a part of user input from the search line field.