### PR TITLE
Move recent files to a separate submenu

### DIFF
--- a/src/settings/include/configuration.h
+++ b/src/settings/include/configuration.h
@@ -57,6 +57,7 @@ enum class SearchRegexpType {
 };
 
 enum class RegexpEngine { Hyperscan, QRegularExpression };
+static constexpr int MAX_RECENT_FILES = 25;
 
 // Configuration class containing everything in the "Settings" dialog
 class Configuration final : public Persistable<Configuration> {

--- a/src/ui/include/mainwindow.h
+++ b/src/ui/include/mainwindow.h
@@ -47,6 +47,7 @@
 #include <memory>
 #include <mutex>
 
+#include "configuration.h"
 #include "crawlerwidget.h"
 #include "downloader.h"
 #include "iconloader.h"
@@ -196,6 +197,7 @@ class MainWindow : public QMainWindow {
     void updateTitleBar( const QString& fileName );
     void addRecentFile( const QString& fileName );
     void updateRecentFileActions();
+    void clearRecentFileActions();
     void updateFavoritesMenu();
     void updateOpenedFilesMenu();
     void updateHighlightersMenu();
@@ -214,11 +216,11 @@ class MainWindow : public QMainWindow {
     WindowSession session_;
     QString loadingFileName;
 
-    enum { MaxRecentFiles = 5 };
-    std::array<QAction*, MaxRecentFiles> recentFileActions;
+    std::array<QAction*, MAX_RECENT_FILES> recentFileActions;
     QActionGroup* recentFilesGroup;
 
     QMenu* fileMenu;
+    QMenu* recentFilesMenu;
     QMenu* editMenu;
     QMenu* viewMenu;
     QMenu* toolsMenu;
@@ -273,6 +275,7 @@ class MainWindow : public QMainWindow {
     QAction* addToFavoritesMenuAction;
     QAction* removeFromFavoritesAction;
     QAction* selectOpenFileAction;
+    QAction* recentFilesCleanup;
     QActionGroup* favoritesGroup;
     QActionGroup* openedFilesGroup;
     QActionGroup* highlightersActionGroup = nullptr;

--- a/src/ui/include/optionsdialog.ui
+++ b/src/ui/include/optionsdialog.ui
@@ -199,6 +199,51 @@
         </widget>
        </item>
        <item>
+        <widget class="QGroupBox" name="recentFilesBox">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="layoutDirection">
+          <enum>Qt::LeftToRight</enum>
+         </property>
+         <property name="title">
+          <string>Recent files</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_recentFilesBox">
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_6">
+            <item>
+             <widget class="QLabel" name="recentFilesLabel">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                <horstretch>1</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string>Show the number of recently opened files:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QSpinBox" name="filesHistoryMaxItemsSpinBox">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
         <spacer name="verticalSpacer">
          <property name="orientation">
           <enum>Qt::Vertical</enum>

--- a/src/ui/include/recentfiles.h
+++ b/src/ui/include/recentfiles.h
@@ -51,7 +51,7 @@ class RecentFiles final : public Persistable<RecentFiles, session_settings> {
     static constexpr int DEFAULT_MAX_ITEMS_TO_SHOW = 5;
 
     QStringList recentFiles_;
-    int filesHistoryMaxItems_ = DEFAULT_MAX_ITEMS_TO_SHOW;
+    int filesHistoryMaxItemsToShow_ = DEFAULT_MAX_ITEMS_TO_SHOW;
 };
 
 #endif

--- a/src/ui/include/recentfiles.h
+++ b/src/ui/include/recentfiles.h
@@ -35,6 +35,10 @@ class RecentFiles final : public Persistable<RecentFiles, session_settings> {
 
     void addRecent( const QString& text );
     void removeRecent( const QString& text );
+    void removeAll();
+    int  getNumberItemsToShow() const;
+    int  filesHistoryMaxItems() const;
+    void setFilesHistoryMaxItems( const int recentFilesItems );
 
     // Returns a list of recent files (latest loaded first)
     QStringList recentFiles() const;
@@ -44,9 +48,10 @@ class RecentFiles final : public Persistable<RecentFiles, session_settings> {
 
   private:
     static constexpr int RECENTFILES_VERSION = 1;
-    static constexpr int MAX_NUMBER_OF_FILES = 10;
+    static constexpr int DEFAULT_MAX_ITEMS_TO_SHOW = 5;
 
     QStringList recentFiles_;
+    int filesHistoryMaxItems_ = DEFAULT_MAX_ITEMS_TO_SHOW;
 };
 
 #endif

--- a/src/ui/src/optionsdialog.cpp
+++ b/src/ui/src/optionsdialog.cpp
@@ -47,6 +47,7 @@
 #include "highlighteredit.h"
 #include "log.h"
 #include "savedsearches.h"
+#include "recentfiles.h"
 #include "shortcuts.h"
 #include "styles.h"
 
@@ -336,6 +337,11 @@ void OptionsDialog::updateDialogFromConfig()
 
     const auto& savedSearches = SavedSearches::get();
     searchHistorySpinBox->setValue( savedSearches.historySize() );
+
+    const auto& recentFiles = RecentFiles::get();
+    filesHistoryMaxItemsSpinBox->setMinimum( 1 );
+    filesHistoryMaxItemsSpinBox->setMaximum( MAX_RECENT_FILES );
+    filesHistoryMaxItemsSpinBox->setValue( recentFiles.filesHistoryMaxItems() );
 }
 
 //
@@ -463,6 +469,10 @@ void OptionsDialog::updateConfigFromDialog()
     auto& savedSearches = SavedSearches::get();
     savedSearches.setHistorySize( searchHistorySpinBox->value() );
     savedSearches.save();
+
+    auto& recentFiles = RecentFiles::get();
+    recentFiles.setFilesHistoryMaxItems( filesHistoryMaxItemsSpinBox->value() );
+    recentFiles.save();
 
     Q_EMIT optionsChanged();
 }

--- a/src/ui/src/recentfiles.cpp
+++ b/src/ui/src/recentfiles.cpp
@@ -22,6 +22,7 @@
 
 #include "log.h"
 #include "recentfiles.h"
+#include "configuration.h"
 
 void RecentFiles::removeRecent( const QString& text )
 {
@@ -35,6 +36,11 @@ void RecentFiles::removeRecent( const QString& text )
     recentFiles_.removeAll( text );
 }
 
+void RecentFiles::removeAll()
+{
+    recentFiles_.clear();
+    recentFiles_.reserve( MAX_RECENT_FILES );
+}
 void RecentFiles::addRecent( const QString& text )
 {
 
@@ -45,8 +51,25 @@ void RecentFiles::addRecent( const QString& text )
     recentFiles_.push_front( text );
 
     // Trim the list if it's too long
-    while ( recentFiles_.size() > MAX_NUMBER_OF_FILES )
+    while ( recentFiles_.size() > MAX_RECENT_FILES )
         recentFiles_.pop_back();
+}
+
+int RecentFiles::getNumberItemsToShow() const
+{
+    return ( filesHistoryMaxItems_ < recentFiles_.count() ? filesHistoryMaxItems_ : recentFiles_.count() );
+}
+
+int RecentFiles::filesHistoryMaxItems() const
+{
+    return filesHistoryMaxItems_;
+}
+
+void RecentFiles::setFilesHistoryMaxItems( const int recentMaxFiles )
+{
+    if ( recentMaxFiles > 0 && recentMaxFiles <= MAX_RECENT_FILES ) {
+        filesHistoryMaxItems_ = recentMaxFiles;
+    }
 }
 
 QStringList RecentFiles::recentFiles() const
@@ -71,6 +94,7 @@ void RecentFiles::saveToStorage( QSettings& settings ) const
         settings.setValue( "name", recentFiles_.at( i ) );
     }
     settings.endArray();
+    settings.setValue( "maxMenuItems", filesHistoryMaxItems_ );
     settings.endGroup();
 }
 
@@ -78,12 +102,13 @@ void RecentFiles::retrieveFromStorage( QSettings& settings )
 {
     LOG_DEBUG << "RecentFiles::retrieveFromStorage";
 
-    recentFiles_.clear();
+    removeAll();
 
     if ( settings.contains( "RecentFiles/version" ) ) {
         settings.beginGroup( "RecentFiles" );
         if ( settings.value( "version" ).toInt() == RECENTFILES_VERSION ) {
             int size = settings.beginReadArray( "filesHistory" );
+            size = ( size < MAX_RECENT_FILES ) ? size : MAX_RECENT_FILES ;
             for ( int i = 0; i < size; ++i ) {
                 settings.setArrayIndex( i );
                 QString file = settings.value( "name" ).toString();
@@ -94,6 +119,7 @@ void RecentFiles::retrieveFromStorage( QSettings& settings )
         else {
             LOG_ERROR << "Unknown version of recent files, ignoring it...";
         }
+        setFilesHistoryMaxItems( settings.value( "maxMenuItems", DEFAULT_MAX_ITEMS_TO_SHOW ).toInt() );
         settings.endGroup();
     }
 }


### PR DESCRIPTION
Changes:
 - move the list of recent files to a dedicated submenu
 - added an option to configure the number of recent files to list
 - added option to clean up the recent files list